### PR TITLE
Update useClickOutside's type to be generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ import React from 'react';
 import useClickOutside from 'click-outside-hook';
 
 export default function SomeAwesomeComponent() {
-  const ref = useClickOutside(() => console.log('my callback'));
+  const ref =
+    useClickOutside < HTMLDivElement > (() => console.log('my callback'));
 
   return (
     <div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 
-export default function useClickOutside(callback: EventListener) {
-  const container = useRef<HTMLElement>(null);
+export default function useClickOutside<T extends HTMLElement>(
+  callback: EventListener
+) {
+  const container = useRef<T>(null);
   const [isTouchEvent, setTouchEvent] = useState(false);
   const eventType = isTouchEvent ? 'touchend' : 'click';
 


### PR DESCRIPTION
I landed some errors in #30, this PR fixes the issue by providing a way to pass Element type during declaration